### PR TITLE
machine_spi.h changed to modmachine.h in Micropython commit 3e2706a

### DIFF
--- a/src/gc9a01.c
+++ b/src/gc9a01.c
@@ -33,7 +33,7 @@
 #include "py/runtime.h"
 #include "py/builtin.h"
 #include "py/mphal.h"
-#include "extmod/machine_spi.h"
+#include "extmod/modmachine.h"
 #include "gc9a01.h"
 
 #include "mpfile.h"


### PR DESCRIPTION
`gc9a01_mpy` build fails to build on recent versions of Micropython. 

On Oct 25, 2023 Micropython combined `machine_mem.h`, `machine_i2c.h` and `machine_spi.h` into a single header called `modmachine.h`: https://github.com/micropython/micropython/commit/3e2706a18dd4071d2d3040549786e659fc3b46b7

This commit reflects that change